### PR TITLE
"Vortragsreihe des CCCS" vorstellen.

### DIFF
--- a/content/events/vortragsreihe.md
+++ b/content/events/vortragsreihe.md
@@ -1,0 +1,42 @@
+-----
+title: Vortragsreihe
+kind: page
+-----
+Nach ersten Anfängen Ende 2003 bietet der CCCS seit Oktober 2004 eine
+monatliche Vortragsreihe zu den verschiedensten Themen (nicht nur)
+rund um IT und Technik, Internet und Medien, Überwachung und
+Datenschutz an, die sich an alle Interessierten mit und ohne
+Vorkenntnisse wendet.
+
+Üblicherweise **jeden zweiten Donnerstag** im Monat sprechen **ab
+19.30 Uhr** (Einlass ab 19.00 Uhr) interne und externe Referenten zu
+ihren jeweiligen Themen; im Anschluss besteht bis gegen 22.00 Uhr noch
+die Möglichkeit zur Diskussion im Anschluss an den Vortrag..
+
+Der **Eintritt** ist kostenlos; um **Spenden** wird gebeten.
+
+Eine Voranmeldung ist nicht erforderlich.
+
+# Danksagung
+
+Die Vortragsreihe des CCCS findet seit September 2008 in den Räumen
+der [Stadtbibliothek Stuttgart](http://www1.stuttgart.de/stadtbibliothek/)
+statt, seit Oktober 2011 in der neuen
+[Bibliothek am Mailänder Platz](http://www1.stuttgart.de/stadtbibliothek/bvs/actions/profile/view.php?id=23).
+
+Die Stadtbibliothek bietet uns freundlicherweise auch die Möglichkeit zur
+[Audioaufzeichnung](www1.stuttgart.de/stadtbibliothek/druck/audio/cccs/cccs_audio.php),
+wofür wir uns herzlich bedanken.
+
+# Geschichte
+
+Anfangs fanden die Vorträge im eher rustikalen Ambiente der
+Wagenhallen im inneren Nordbahnhof statt; nach einem kurzen Gastspiel
+im Umweltzentrum des BUND in der Rotebühlstraße von September bis
+Dezember 2005 konnten wir ab Januar 2006 freundlicherweise in
+Kooperation mit [Wand 5](http://www.wand5.de/) einen Raum des
+Kommunalen Kinos im Filmhaus in der Friedrichstraße nutzen.
+
+Seit September 2008 besteht die Kooperation mit der Stadtbibliothek,
+die uns zunächst im Wilhemspalais und dann ab Oktober 2011 in den
+neuen Räumlichkeiten am Mailänder Platz aufgenommen hat.

--- a/layouts/default.html
+++ b/layouts/default.html
@@ -43,6 +43,7 @@
               </ul>
               <% elsif (path_section(item,1)=="events") %>
               <ul class="nav span11">
+                <li><a<%= menu_active_if("vortragsreihe",2)%> href="/events/vortragsreihe/">Vortragsreihe</a>
                 <li><a<%= menu_active_if("stream",2)%> href="/events/stream/">Livestream</a>
               </ul>
               <% elsif (path_section(item,1)=="archives") %>


### PR DESCRIPTION
Ich würde anregen, die Vortragsreihe des CCCS auch an sich als eigene Veranstaltung vorzustellen und in die Navigation vor dem Item "Livestream" einzubinden.

Der Text ist inhaltlich größtenteils aus dem alten Wiki übernommen und um einen kurzen historischen Abriss der Vortrags-Locations ergänzt.
