### PR TITLE
Fix hierarchy of headings.

### DIFF
--- a/content/events/201307-der-facebook-hack/index.md
+++ b/content/events/201307-der-facebook-hack/index.md
@@ -40,7 +40,7 @@ an die Grundrechte und durch eine demokratische Kontrolle gebunden. Es
 stellt sich die Frage, ob das staatliche Gewaltmonopol in Gefahr ist.
 
 
-# Zur Person
+## Zur Person
 
 Sierk Hamann, Jurist aus Tübingen.
 Die ersten Reisen im Cyberspace mit NCSA Mosaic,

--- a/content/events/201311-digitale-langzeitarchivierung/index.md
+++ b/content/events/201311-digitale-langzeitarchivierung/index.md
@@ -45,7 +45,7 @@ eigenen digitalen "Kram", der für Kinder und Enkel interessant sein könnte,
 fallen vielleicht auch praktische Tipps für die Zuhörer ab.
 
 
-# Zur Person
+## Zur Person
 
 Heinz Werner Kramski hat 1990 ein Lehramtsstudium (Geschichte und
 Germanistik) an der Westfälischen Wilhelmsuniversität Münster abgeschlossen

--- a/content/events/201405-datenzugriff-ermittlungsbehoerden/index.md
+++ b/content/events/201405-datenzugriff-ermittlungsbehoerden/index.md
@@ -46,7 +46,7 @@ Die Veranstaltung richtet sich an jeden, der sich für das Thema
 interessiert. Besondere juristische oder technische Vorkenntnisse
 werden nicht vorausgesetzt.
 
-# Zur Person
+## Zur Person
 
 Thomas Hochstein ist Staatsanwalt in Stuttgart und interessiert
 sich sowohl für das Netz und seine Dienste als auch für

--- a/content/events/vortragsreihe.md
+++ b/content/events/vortragsreihe.md
@@ -17,7 +17,7 @@ Der **Eintritt** ist kostenlos; um **Spenden** wird gebeten.
 
 Eine Voranmeldung ist nicht erforderlich.
 
-# Danksagung
+## Danksagung
 
 Die Vortragsreihe des CCCS findet seit September 2008 in den Räumen
 der [Stadtbibliothek Stuttgart](http://www1.stuttgart.de/stadtbibliothek/)
@@ -28,7 +28,7 @@ Die Stadtbibliothek bietet uns freundlicherweise auch die Möglichkeit zur
 [Audioaufzeichnung](www1.stuttgart.de/stadtbibliothek/druck/audio/cccs/cccs_audio.php),
 wofür wir uns herzlich bedanken.
 
-# Geschichte
+## Geschichte
 
 Anfangs fanden die Vorträge im eher rustikalen Ambiente der
 Wagenhallen im inneren Nordbahnhof statt; nach einem kurzen Gastspiel


### PR DESCRIPTION
'Title' is inserted as &lt;h1&gt;, so all sub-headings
should be &lt;h2&gt; (or deeper). Change '#' to '##' in
markdown accordingly, where appropriate.

Signed-off-by: Thomas Hochstein thh@inter.net
