### PR TITLE
ignore rvm files and vendor directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 .*.swp
 crash.log
 /.sass-cache
-
+.rvmrc
+/vendor/*


### PR DESCRIPTION
Falls jemand RVM verwendet und/oder "bundle pack" ausführt.