### PR TITLE
Fix wording and typo.

### DIFF
--- a/content/events/vortragsreihe.md
+++ b/content/events/vortragsreihe.md
@@ -10,8 +10,8 @@ Vorkenntnisse wendet.
 
 Üblicherweise **jeden zweiten Donnerstag** im Monat sprechen **ab
 19.30 Uhr** (Einlass ab 19.00 Uhr) interne und externe Referenten zu
-ihren jeweiligen Themen; im Anschluss besteht bis gegen 22.00 Uhr noch
-die Möglichkeit zur Diskussion im Anschluss an den Vortrag..
+ihren jeweiligen Themen; danach besteht bis gegen 22.00 Uhr noch
+die Möglichkeit zur Diskussion im Anschluss an den Vortrag.
 
 Der **Eintritt** ist kostenlos; um **Spenden** wird gebeten.
 


### PR DESCRIPTION
Once "im Anschluss" should be enough, as should one
full stop (not two).

Signed-off-by: Thomas Hochstein <thh@inter.net>