### PR TITLE
Adapt personal background.

### DIFF
--- a/content/events/201706-praesentation/index.md
+++ b/content/events/201706-praesentation/index.md
@@ -19,6 +19,7 @@ Aufzählungspunkte waren vorgestern. Heute zeigt man Bilder, erzählt Geschichte
 
 Wie und warum moderne Präsentationen funktionieren erklärt dieser Vortrag.
 
-Über den Vortragenden:
+## Zur Person
+
 Dirk Haun ist Organisator und Speaker Coach bei TEDxStuttgart und Autor von "Präsentieren für Geeks". 
 Er arbeitet als selbstständiger Präsentations-Coach in Stuttgart.

--- a/content/events/201706-praesentation/index.md
+++ b/content/events/201706-praesentation/index.md
@@ -1,5 +1,7 @@
-duration: 2h
+---
+kind: event
 startdate: 2017-06-08T19:30:00Z
+duration: 2h
 title: "Stoppt die Bullet Points! Was eine moderne Präsentation ausmacht"
 speakers:
   -


### PR DESCRIPTION
It has always (?) been "Zur Person", as a heading.

Signed-off-by: Thomas Hochstein <thh@inter.net>