### PR TITLE
Add links to external audio recordings to all talks that lack recordings.

### DIFF
--- a/content/events/201508-hallo-mobile-welt/index.md
+++ b/content/events/201508-hallo-mobile-welt/index.md
@@ -13,6 +13,7 @@ material:
   -
     file: hallo-mobile-welt.pdf
     title: Folien (PDF)
+audio: 'http://www.stadtbuecherei-stuttgart-audio.de/CCCS/13082015_CCCS_Hannah.mp3'
 ---
 Suchst Du vergeblich nach einer bestimmten App in den verschiedenen
 App-Shops? Statt darauf zu warten, bis sie jemand für dich entwickelt,

--- a/content/events/201603-vds/index.md
+++ b/content/events/201603-vds/index.md
@@ -14,7 +14,7 @@ material:
   -
     title: Präsentation
     link: https://stefan.leibfarth.org/slides/vds.cccs/ 
-#audio: 
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2016-04-21_2016_03_10_vorratsdatenspeicherung_fuer_dummys.mp3' 
 ---
 Im Oktober 2015 wurde im Bundestag die Wiedereinführung der zuvor
 vom Verfassungsgericht gestoppten Vorratsdatenspeicherung beschlossen.

--- a/content/events/201605-nsaua/index.md
+++ b/content/events/201605-nsaua/index.md
@@ -14,7 +14,7 @@ public: true
 #  -
 #    file:
 #    title:
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2016-05-25_cccs_lesung_nsa_ausschuss.mp3'
 ---
 In den mehrere hundert A4-Seiten füllenden Protokollen des
 NSA-BND-Untersuchungsausschusses, die bei netzpolitik.org nachzulesen

--- a/content/events/201606-safe-harbour-2.0-dsgv/index.md
+++ b/content/events/201606-safe-harbour-2.0-dsgv/index.md
@@ -14,6 +14,7 @@ material:
   -
     file: 201606-safe-harbour-20-dsgv.pdf
     title: Folien (PDF)
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2016-06-14_09062016_cccs_drchristianborchers.mp3'
 ---
 Der EU US Privacy Shield und die EU Datenschutz-Grundverordnung
 

--- a/content/events/201608-it-infrastruktur-selber-betreiben/index.md
+++ b/content/events/201608-it-infrastruktur-selber-betreiben/index.md
@@ -16,7 +16,7 @@ material:
   -
     file: 201608-it-infrastruktur-selber-betreiben-handout.pdf
     title: Handout
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2016-08-23_cccs_it_infrastruktur.mp3'
 ---
 Aufgabenstellung: Wenn personenbezogene Daten in einer selbstständigen
 Tätigkeit verarbeitet werden müssen, steht man schnell vor dem Problem,

--- a/content/events/201609-ueberwachung-journalisten/index.md
+++ b/content/events/201609-ueberwachung-journalisten/index.md
@@ -13,7 +13,7 @@ public: true
 #  -
 #    file:
 #    title:
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2016-09-19_08092016_cccs_welchering_schereimkopf.mp3'
 ---
 Die Große Koalition hat die Vorratsdatenspeicherung durchgepeitscht. Mit der dort vorgesehenen zehnwöchigen Speicherpflicht für Verkehrsdaten und der vierwöchigen Speicherpflicht für Handy-Standortdaten wird es Journalisten wesentlich erschwert, die Identität ihrer Informanten zu schützen.
 

--- a/content/events/201701-wo-bleibt-mein-glasfaseranschluss/index.md
+++ b/content/events/201701-wo-bleibt-mein-glasfaseranschluss/index.md
@@ -13,7 +13,7 @@ material:
   -
     file: 20170112-glasfaser.pdf
     title: Folien
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2017-01-24_12012017_cccs_pi_glasfaser.mp3'
 ---
 Glasfaseranschluesse sind die beste Technologie fuer den sehr schnellen Internetzugang.
 Doch auch 2017 ist ein Glasfaseranschluss fuer die meisten BuergerInnen und Unternehmen nicht verfuegbar.

--- a/content/events/201702-senior-consulting/index.md
+++ b/content/events/201702-senior-consulting/index.md
@@ -13,7 +13,7 @@ material:
   -
     title: Folien
     file: SenCons-CCCS-201702_V09.pdf
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2017-03-10_20170209_cccs_beratung.mp3'
 ---
 Die Unlust, familieninternen Computersupport zu leisten, ist unter Nerds mehr oder weniger stark ausgeprägt. Aber es gibt Menschen, die uns beigebracht haben, die einfachsten technischen Hilfsmittel zu benutzen (und seien es Messer und Gabel): unsere Eltern. Manchmal ist Zeit, ihnen etwas zurückzugeben.
 

--- a/content/events/201703-messenger/index.md
+++ b/content/events/201703-messenger/index.md
@@ -13,7 +13,7 @@ material:
   -
     title: Folien
     link: https://stefan.leibfarth.org/slides/whatsapp17/
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2017-03-10_20170309_cccs_messenger.mp3'
 ---
 Messenger auf unseres Smartphones sind auch 2017 ein viel diskutiertes Thema. Immer wieder ist von deren Verschlüsselung, Unsicherheit oder Datenschutzproblemen zu lesen.
 Doch wie ist der aktuelle Stand der Dinge?

--- a/content/events/201705-wikipedia/index.md
+++ b/content/events/201705-wikipedia/index.md
@@ -13,7 +13,7 @@ public: true
 #  -
 #    file:
 #    title:
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2017-05-16_cccs_wikipedia.mp3'
 ---
 Das Wissen der Welt wird u.a. über die Wikipedia von tausenden von Freiwilligen bereitgestellt. 
 Wie funktioniert das - und warum? 

--- a/content/events/201706-praesentation/index.md
+++ b/content/events/201706-praesentation/index.md
@@ -13,7 +13,7 @@ public: true
 #  -
 #    file:
 #    title:
-#audio:
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2017-06-09_08_06_17_stoppt_die_bulletpoints.mp3'
 ---
 Aufzählungspunkte waren vorgestern. Heute zeigt man Bilder, erzählt Geschichten und richtet sich nach dem Publikum. 
 

--- a/content/events/201707-speicherpflichten-auskunft-verkehrsdaten/index.md
+++ b/content/events/201707-speicherpflichten-auskunft-verkehrsdaten/index.md
@@ -10,6 +10,7 @@ speakers:
 location:
   location: bib
 public: true
+audio: 'http://rss.stadtbuecherei-stuttgart-audio.de/pg/media/2017-07-28_cccs_vorratsdatenspeicherung2.mp3'
 ---
 Mit dem Ende des Monats Juni 2017 läuft die Übergangsfrist des
 § 150 Abs. 13 Telekommunikationsgesetz (TKG) für die Umsetzung der

--- a/layouts/event_header.erb
+++ b/layouts/event_header.erb
@@ -70,7 +70,7 @@
                     </li>
                     <% end %>
                     <% if @item[:audio] %>
-                    <li class="icon-music" title="Audiomitschnitt"> <%= datalink(@item[:audio], 'Audiomitschnitt') %></li>
+                    <li class="icon-music" title="Audiomitschnitt"><% if @item[:audio][/^https?:/] %><a href="<%= @item[:audio] %>">Audiomitschnitt</a><% else %><%= datalink(@item[:audio], 'Audiomitschnitt') %><% end %></li>
                     <% end %>
                     <% if @item[:material] %>
                     <li class="icon-pencil commaseparated" title="Begleitmaterial und Folien">


### PR DESCRIPTION
I understand the wish to keep all files local to avoid linkrot - but there are lots of recorded talks in 2016 and 2017 that don't have their recordings uploaded yet. In fact, we have just two recordings linked in 2016 and none in 2017.

As I can't upload recordings to the separate data dir I suggest to add links to the Stadtbibliothek recordings for the time being. A link that may become broken sometimes in the future is much better than no link at all.

I'd be willing to add an issue to track all recordings that have been linked and need to be uploaded in the future, if that's desired.