### PR TITLE
Corona-Regelungen verlinken und ergänzen

### DIFF
--- a/content/events/202007-safety-first/index.md
+++ b/content/events/202007-safety-first/index.md
@@ -15,3 +15,5 @@ sonstiger Schadsoftware? Um sich wirkungsvoll schützen zu können, ist es
 wichtig, sich  vorzubereiten. In diesem Vortrag erfahren Sie, wie Sie Ihren 
 Computer und Ihre Daten schützen und lernen Sie Angriffspunkte und 
 Schwachstellen kennen.
+
+**Bitte beachtet die [geltenden Regeln der Bibliothek und die Reservierungspflicht!](/2020-06-10-vortragsreihe-coronaregelungen)**

--- a/content/events/vortragsreihe.md
+++ b/content/events/vortragsreihe.md
@@ -15,7 +15,8 @@ die Möglichkeit zur Diskussion im Anschluss an den Vortrag.
 
 Der **Eintritt** ist kostenlos; um **Spenden** wird gebeten.
 
-Eine Voranmeldung ist nicht erforderlich.
+Bitte beachtet die derzeit geltenden [Corona-Regelungen](/2020-06-10-vortragsreihe-coronaregelungen/).
+Dazu gehört insbesondere auch eine **Anmeldepflicht**!
 
 ## Danksagung
 


### PR DESCRIPTION
Auf der Infoseite zur Vortragsreihe steht noch, es bedürfe keiner Anmeldung. Stattdessen sollte auf die Corona-Regelungen verwiesen werden.

Der Juli-Vortrag sollte ebenso wie der Vortrag nächste Woche einen entsprechenden Hinweis erhalten. Streichen kann man den immer noch.